### PR TITLE
feat: Add python dice roll API with OpenTelemetry tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Environments
+.env
+.venv
+
+# VS code files
+.vscode/

--- a/exampleApps/python/README.md
+++ b/exampleApps/python/README.md
@@ -1,0 +1,64 @@
+# Python Dice Roll API with OpenTelemetry
+
+A simple Bottle API that simulates rolling dice with built-in OpenTelemetry tracing.
+
+## Features
+
+- Roll multiple 6-sided dice
+- OpenTelemetry instrumentation
+- HTML interface
+- Error handling
+- Trace exports to OTLP collector
+
+## Setup
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Set collector endpoint (optional)
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+
+# Run the server
+python app.py
+```
+
+## API Usage
+
+### Roll Dice
+
+- Endpoint: `/rolldice`
+- Method: GET
+- Query Parameter: `rolls` (integer, 1-100)
+- Example: `http://localhost:8080/rolldice?rolls=3`
+
+### Response Format
+
+```json
+{
+  "dice": 3,
+  "results": [4, 6, 2]
+}
+```
+
+## Files Structure
+
+- `app.py` - Main application server
+- `dice.py` - Dice rolling logic with tracing
+- `instrumentation.py` - OpenTelemetry setup
+- `public/index.html` - Web interface
+- `static/style.css` - Styling
+
+## OpenTelemetry Integration
+
+The application uses OpenTelemetry for tracing:
+
+- Traces dice rolls individually
+- Records roll results as span attributes
+- Exports traces to configured OTLP endpoint
+
+## Environment Variables
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: Collector endpoint (default: http://localhost:4318)
+- `APP_HOST`: Host to bind (default: localhost)
+- `APP_PORT`: Port to listen on (default: 8080)

--- a/exampleApps/python/app.py
+++ b/exampleApps/python/app.py
@@ -1,0 +1,48 @@
+from bottle import Bottle, request, response, run, static_file, template
+import json
+import os
+
+from dice import roll_dice
+
+app = Bottle()
+
+
+# Serve static files (CSS)
+@app.get("/static/<filename>")
+def serve_static(filename):
+    return static_file(filename, root="./static")
+
+
+# Homepage
+@app.get("/")
+def homepage():
+    return template("public/index.html")
+
+
+@app.get("/rolldice")
+def api_roll():
+    """
+    API endpoint to roll dice.
+    :param rolls: Number of dice to roll (default is 1)
+    :return: JSON response with the results of the dice rolls
+    """
+    # Get query parameters
+    # Example: /rolldice?rolls=2
+    try:
+        num_dice = int(request.query.get("rolls", 1))
+        result = roll_dice(num_dice)
+        response.content_type = "application/json"
+        return json.dumps({"dice": num_dice, "results": result})
+
+    except ValueError as ve:
+        response.status = 400
+        return {"error": str(ve)}
+    except Exception:
+        response.status = 500
+        return {"error": "Internal server error"}
+
+
+if __name__ == "__main__":
+    host = os.getenv("APP_HOST", "localhost")
+    port = int(os.getenv("APP_PORT", "8080"))
+    run(app, host="localhost", port=8080, debug=True)

--- a/exampleApps/python/dice.py
+++ b/exampleApps/python/dice.py
@@ -1,0 +1,42 @@
+import random
+from instrumentation import tracer
+
+
+def roll_once(i: int, min_val: int, max_val: int) -> int:
+    """
+    Roll a single die with tracing.
+
+    Args:
+        i (int): Roll index for span naming
+        min_val (int): Minimum value (inclusive)
+        max_val (int): Maximum value (exclusive)
+
+    Returns:
+        int: Result of the die roll
+    """
+    with tracer.start_as_current_span(f"rollOnce:{i}") as span:
+        result = random.randint(min_val, max_val - 1)
+        span.set_attribute("dicelib.rolled", str(result))
+        return result
+
+
+def roll_dice(num_dice: int) -> list:
+    """
+    Roll multiple dice with tracing.
+
+    Args:
+        num_dice (int): Number of dice to roll (1-100)
+
+    Returns:
+        list: Results of all dice rolls
+
+    Raises:
+        ValueError: If num_dice is not between 1 and 100
+    """
+    sides = 6  # Always 6-sided dice as per app.py logic
+    if not (1 <= num_dice <= 100):
+        raise ValueError("Number of dice must be between 1 and 100.")
+    with tracer.start_as_current_span("rollTheDice") as span:
+        results = [roll_once(i, 1, sides + 1) for i in range(num_dice)]
+        span.add_event("Dice rolled", {"results": results, "total": sum(results)})
+        return results

--- a/exampleApps/python/instrumentation.py
+++ b/exampleApps/python/instrumentation.py
@@ -1,0 +1,35 @@
+import os
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+# Configuration from environment variables
+SERVICE_NAME = os.getenv("SERVICE_NAME", "python-dice-server")
+SERVICE_VERSION = os.getenv("SERVICE_VERSION", "0.1.0")
+OTEL_EXPORT_ENDPOINT = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+
+# Create a resource with service information
+resource = Resource.create(
+    {
+        "service.name": SERVICE_NAME,
+        "service.version": SERVICE_VERSION,
+    }
+)
+
+# Configure the trace provider with the resource
+trace_provider = TracerProvider(resource=resource)
+trace.set_tracer_provider(trace_provider)
+
+# Set up the OTLP exporter for traces
+trace_exporter = OTLPSpanExporter(
+    endpoint=f"{OTEL_EXPORT_ENDPOINT}/v1/traces",
+)
+
+# Configure batch processing of spans
+span_processor = BatchSpanProcessor(trace_exporter)
+trace.get_tracer_provider().add_span_processor(span_processor)
+
+# Create a tracer for use throughout the application
+tracer = trace.get_tracer(__name__)

--- a/exampleApps/python/public/index.html
+++ b/exampleApps/python/public/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Dice Roll API</title>
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <h1>🎲 Dice Roll API</h1>
+      <p>Welcome to the Dice Roll API server.</p>
+      <h2>Usage</h2>
+      <p>
+        Make a GET request to the <code>/rolldice</code> endpoint with this
+        query parameter:
+      </p>
+      <ul>
+        <li><code>rolls</code>: Number of dice to roll (1–100)</li>
+      </ul>
+      <h3>Example:</h3>
+      <code>/rolldice?rolls=3</code>
+      <p>Returns a JSON object with roll results (each die has 6 sides).</p>
+    </div>
+  </body>
+</html>

--- a/exampleApps/python/requirements.txt
+++ b/exampleApps/python/requirements.txt
@@ -1,0 +1,5 @@
+bottle>=0.13.3
+opentelemetry-api>=1.30.0
+opentelemetry-sdk>=1.30.0
+opentelemetry-exporter-otlp>=1.30.0
+opentelemetry-instrumentation-logging>=0.51b0

--- a/exampleApps/python/static/style.css
+++ b/exampleApps/python/static/style.css
@@ -1,0 +1,27 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f7f7f7;
+  color: #333;
+  padding: 20px;
+}
+
+.container {
+  max-width: 600px;
+  margin: auto;
+  background: #fff;
+  padding: 30px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+  color: #4caf50;
+}
+
+code {
+  background-color: #eee;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: "Fira Mono", "Consolas", monospace;
+  font-size: 1em;
+}


### PR DESCRIPTION
feat: Add python dice roll API with OpenTelemetry tracing

- Implement REST API for rolling 6-sided dice
- Add OpenTelemetry instrumentation for request tracing
- Include HTML interface and documentation
- Configure OTLP export to collector